### PR TITLE
Changed the way maximum velocity is capped, fixing 2 importants bugs:

### DIFF
--- a/src/org/flixel/plugin/photonstorm/FlxControlHandler.as
+++ b/src/org/flixel/plugin/photonstorm/FlxControlHandler.as
@@ -1183,14 +1183,30 @@ package org.flixel.plugin.photonstorm
 			
 			if (capVelocity)
 			{
-				if (entity.velocity.x > entity.maxVelocity.x)
+				if (entity.velocity.x != 0 && entity.velocity.y != 0)
 				{
-					entity.velocity.x = entity.maxVelocity.x;
+					// If both velocities are non-zero, we cap them to: maxValue * (sqrt(2) / 2)
+					if (Math.abs(entity.velocity.x) > (entity.maxVelocity.x * 0.70711))
+					{
+						entity.velocity.x = FlxMath.getSignOfNumber(entity.velocity.x) * entity.maxVelocity.x * 0.70711;
+					}
+					
+					if (Math.abs(entity.velocity.y) > (entity.maxVelocity.y * 0.70711) )
+					{
+						entity.velocity.y = FlxMath.getSignOfNumber(entity.velocity.y) * entity.maxVelocity.y * 0.70711;
+					}
 				}
-				
-				if (entity.velocity.y > entity.maxVelocity.y)
+				else
 				{
-					entity.velocity.y = entity.maxVelocity.y;
+					if (Math.abs(entity.velocity.x) > entity.maxVelocity.x)
+					{
+						entity.velocity.x = FlxMath.getSignOfNumber(entity.velocity.x) * entity.maxVelocity.x;
+					}
+					
+					if (Math.abs(entity.velocity.y) > entity.maxVelocity.y)
+					{
+						entity.velocity.y = FlxMath.getSignOfNumber(entity.velocity.y) * entity.maxVelocity.y;
+					}
 				}
 			}
 			

--- a/src/org/flixel/plugin/photonstorm/FlxMath.as
+++ b/src/org/flixel/plugin/photonstorm/FlxMath.as
@@ -482,6 +482,30 @@ package org.flixel.plugin.photonstorm
         {
             return ax * bx + ay * by;
         }
+
+        /**
+         * Returns either -1 or 1 depending on the sign of the input int value. Notice: sign of 0 is 1
+         * 
+         * @param 	val 	Input int value
+         *
+         * @return Sign of input (int)
+         */
+        public static function getSignOfInt(val : int):int
+		{
+			return (val >= 0 ? 1 : -1);
+		}
+		
+		/**
+         * Returns either -1 or 1 (number) depending on the sign of the input number value. Notice: sign of 0 is 1
+         * 
+         * @param 	val 	Input number value
+         *
+         * @return Sign of input (number)
+         */
+		public static function getSignOfNumber(val : Number):Number
+		{
+			return (val >= 0.0 ? 1.0 : -1.0);
+		}
         
 		/**
 		 * Randomly returns either a 1 or -1


### PR DESCRIPTION
- The check about max velocity in either directions now takes the ABS
  value of the current speed into account (before, negative speeds were
  not capped)
- When both x and y velocity are nonzero, we cap both of them to maxVel *
  sqrt(3) / 2, which is mathematically correct and prevent characters
  moving diagonal to exceed the max speed (so they don't go faster when
  they move diagonally)
